### PR TITLE
ClassLoader.getSystemResource throws an exception, but

### DIFF
--- a/lvz-viz/src/main/java/de/codefor/le/ner/NER.java
+++ b/lvz-viz/src/main/java/de/codefor/le/ner/NER.java
@@ -83,7 +83,7 @@ public class NER {
         final Collection<String> blacklist = new HashSet<>();
         List<String> lines = null;
         try {
-            lines = Files.readAllLines(Paths.get(ClassLoader.getSystemResource(BLACKLIST_FILE).toURI()),
+            lines = Files.readAllLines(Paths.get(NER.class.getClassLoader().getResource(BLACKLIST_FILE).toURI()),
                     StandardCharsets.UTF_8);
         } catch (final IOException | URISyntaxException e) {
             throw Throwables.propagate(e);


### PR DESCRIPTION
NER.class.getClassLoader().getResource works for me