### PR TITLE
Use gradle-node-plugin to run grunt within gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,27 +14,28 @@ by [OK Lab Leipzig](http://codefor.de/projekte/2014-07-01-le-lvz_polizeiticker_v
 Build and run the app with [npm](https://www.npmjs.com), [Grunt](http://gruntjs.com/) and [Gradle](https://gradle.org).
 The crawling and indexing of new articles is activated by the startup parameter --spring.profiles.active=crawl.
 
-### npm and Grunt
-
-Download client js dependencies with npm and package them with Grunt during postinstall phase.
-
-    npm install
-
-### Gradle
+### Gradle, npm and Grunt
 
 You can build an executable jar with gradle and run it as a separate process.
+The client js dependencies will be downloaded with npm and packaged with Grunt during the build phase from gradle.
 
-    ./gradlew build
-    java -jar build/libs/lvz-viz-*.jar
+```
+./gradlew build
+java -jar build/libs/lvz-viz-*.jar
+```
 
 You can build an executable jar with gradle and skip all tests to speed up the build.
 
-    ./gradlew build -x test
-    java -jar build/libs/lvz-viz-*.jar
+```
+./gradlew build -x test
+java -jar build/libs/lvz-viz-*.jar
+```
 
 Or you can simply run the project within gradle during development.
 
-    ./gradlew bootRun
+```
+./gradlew bootRun
+```
 
 ### Docker
 
@@ -42,7 +43,9 @@ You can build and run the app within a Docker container.
 
 Required version for the multi-stage build: Docker 17.05+
 
-    docker-compose build
-    docker-compose up -d
-    docker-compose logs -f
-    docker-compose down
+```
+docker-compose build
+docker-compose up -d
+docker-compose logs -f
+docker-compose down
+```

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ buildscript {
   }
 }
 
+plugins {
+  id "com.moowork.grunt" version "1.2.0"
+}
+
 apply plugin: 'java'
 apply plugin: 'eclipse-wtp'
 apply plugin: 'idea'
@@ -77,3 +81,7 @@ eclipse {
   }
 }
 
+// see https://github.com/srs/gradle-node-plugin/blob/master/docs/grunt.md
+grunt_default.dependsOn 'npmInstall'
+// run grunt default in findMainClass which runs after :processResources b/c all resources are copied and grunt can do his job
+findMainClass.dependsOn(grunt_default)

--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
   "devDependencies": {
     "grunt-contrib-watch": "^1.0.1",
     "grunt-html-angular-validate": "^0.6.1"
-  },
-  "scripts": {
-    "postinstall": "grunt"
   }
 }


### PR DESCRIPTION
* remove postinstall script, this runs with gradle bootRun
* process npm install before grunt default
* use phase findMainClass to run grunt task b/c resources are copied

I created this pull request, because I noticed that grunt must always be executed after **bootRun**, because the resources are overridden by gradle and the **app.min.js** is no longer available. This way is therefore a simplification.

@sepe81 fyi