### PR TITLE
Fix crawling after the redesign of LVZ website

### DIFF
--- a/src/main/java/de/codefor/le/crawler/LvzPoliceTickerDetailViewCrawler.java
+++ b/src/main/java/de/codefor/le/crawler/LvzPoliceTickerDetailViewCrawler.java
@@ -123,7 +123,7 @@ public class LvzPoliceTickerDetailViewCrawler {
 
     private static void extractTitle(final Document doc, final PoliceTicker dm) {
         final String title = "title";
-        final String cssQuery = "h1.pda-entry-title.entry-title";
+        final String cssQuery = ".pdb-article-teaser-breadcrumb-headline-title";
         final Element elem = doc.selectFirst(cssQuery);
         if (elem != null) {
             logger.debug(LOG_ELEMENT_FOUND, title, cssQuery);
@@ -148,26 +148,20 @@ public class LvzPoliceTickerDetailViewCrawler {
     }
 
     /**
-     * Try different selectors for publishing date.
+     * Try to extract the publishing date from a script block.
      *
      * @param doc Document
      * @param dm PoliceTicker
      */
     private static void extractDatePublished(final Document doc, final PoliceTicker dm) {
         final String publishingDate = "publishing date";
-        String cssQuery = "span.dtstamp";
+        String cssQuery = ".pdb-article > script[type=application/ld+json]";
         Element elem = doc.selectFirst(cssQuery);
         if (elem != null) {
             logger.debug(LOG_ELEMENT_FOUND, publishingDate, cssQuery);
-        } else {
-            cssQuery = "meta[itemprop=datepublished]";
-            elem = doc.selectFirst(cssQuery);
-            if (elem != null) {
-                logger.debug(LOG_ELEMENT_FOUND, publishingDate, cssQuery);
-            }
-        }
-        if (elem != null) {
-            dm.setDatePublished(extractDate(elem.attr("content")));
+            String date = elem.data();
+            int startIndex = date.indexOf("datePublished") + 17;
+            dm.setDatePublished(extractDate(date.substring(startIndex, startIndex + 25)));
         }
         if (dm.getDatePublished() == null) {
             logger.warn(LOG_ELEMENT_NOT_FOUND, publishingDate);
@@ -198,7 +192,7 @@ public class LvzPoliceTickerDetailViewCrawler {
 
     private static void extractArticleAndSnippet(final Document doc, final PoliceTicker dm) {
         final String content = "articlecontent";
-        final String cssQuery = "#articlecontent > p.pda-abody-p";
+        final String cssQuery = ".pdb-article-body > .ezxmltext-field > p";
         final Elements elements = doc.select(cssQuery);
         if (!elements.isEmpty()) {
             logger.debug(LOG_ELEMENT_FOUND, content, cssQuery);

--- a/src/test/java/de/codefor/le/crawler/LvzPoliceTickerCrawlerTest.java
+++ b/src/test/java/de/codefor/le/crawler/LvzPoliceTickerCrawlerTest.java
@@ -1,11 +1,11 @@
 package de.codefor.le.crawler;
 
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -14,27 +14,18 @@ import org.junit.Test;
 
 public class LvzPoliceTickerCrawlerTest {
 
-    private static final String OLDEST_URL = "http://www.lvz.de/Leipzig/Polizeiticker/Polizeiticker-Leipzig/Ladendetektive-schnappen-an-einem-Tag-vier-Diebe-im-Leipziger-Zentrum";
-
     private final LvzPoliceTickerCrawler crawler = new LvzPoliceTickerCrawler();
 
     @Test
-    public void testExecuteForPageWithOffsetZero() throws InterruptedException, ExecutionException {
+    public void testExecuteForPageZeroAndOne() throws InterruptedException, ExecutionException {
         final Future<Iterable<String>> future = crawler.execute(0);
         assertNotNull(future);
         final Iterable<String> pageOne = future.get();
         assertNotNull(pageOne);
-        final Iterator<String> it = pageOne.iterator();
-        assertTrue(it.hasNext());
-        final String firstArticleUrl = it.next();
+        final String firstArticleUrl = pageOne.iterator().next();
         assertThat(firstArticleUrl, startsWith(LvzPoliceTickerCrawler.LVZ_POLICE_TICKER_BASE_URL));
-    }
 
-    @Test
-    public void testExecuteForPageWithOffset6538() throws InterruptedException, ExecutionException {
-        final Iterable<String> result = crawler.execute(6538).get();
-        assertNotNull(result);
-        assertThat(result, Matchers.hasItem(OLDEST_URL));
+        assertEquals(firstArticleUrl, crawler.execute(1).get().iterator().next());
     }
 
     @Test

--- a/src/test/java/de/codefor/le/crawler/LvzPoliceTickerDetailViewCrawlerTest.java
+++ b/src/test/java/de/codefor/le/crawler/LvzPoliceTickerDetailViewCrawlerTest.java
@@ -26,7 +26,7 @@ public class LvzPoliceTickerDetailViewCrawlerTest {
 
     private static final Date PUBLISHING_DATE = getDate(LocalDateTime.of(2015, 10, 11, 15, 13));
 
-    private static final String ARTICLE = "Leipzig. Fast ein halbes Jahr nach einem tödlichen Kranunfall in der Leipziger Innenstadt "
+    private static final String ARTICLE = "Fast ein halbes Jahr nach einem tödlichen Kranunfall in der Leipziger Innenstadt "
             + "ist die Verantwortung noch immer unklar. Ein technisches Gutachten liege inzwischen vor, "
             + "sagte ein Sprecher der Staatsanwaltschaft in Leipzig. Es sei aber noch unklar, "
             + "ob für das Unglück jemand strafrechtlich verantwortlich gemacht werden könne. "
@@ -46,7 +46,6 @@ public class LvzPoliceTickerDetailViewCrawlerTest {
         urls.add(BASE_URL + "/Ermittlungen-nach-toedlichem-Kranunfall-in-Leipzig-City-dauern-an");
         urls.add(BASE_URL + "/Betrunkene-rauscht-im-Leipziger-Zentrum-ins-Gleisbett");
         urls.add(BASE_URL + "/Taeter-nach-Boellerwurf-in-Asylbewerberwohnung-gefasst");
-        urls.add(BASE_URL + "/Autoanhaenger-mit-Legida-Buehne-in-Leipzig-mit-Molotow-Cocktails-angegriffen");
         urls.add("http://www.lvz.de/Specials/Themenspecials/Legida-und-Proteste"
                 + "/Pegida/Nach-Pegida-Auseinandersetzung-auch-am-Leipziger-Hauptbahnhof");
 


### PR DESCRIPTION
Since 20 April 2018 all articles under
http://www.lvz.de/Leipzig/Polizeiticker/Polizeiticker-Leipzig/
have new CSS classes and the site structure has totally changed.
Furthermore the pagination only works until site #4
(http://www.lvz.de/Leipzig/Polizeiticker/Polizeiticker-Leipzig/4#anchor).
Older articles can only be addressed over the archive (http://www.lvz.de/Archiv).

Explicitly check for policeticker articles b/c other articles are also displayed in the overview.

Ignore the location label that is part of some articles.

The publishing date with complete date, time and timezone is not part of the site layout anymore.
Therefore try to extract it from some scripting content.

Crawling from the archive is not part of this commit.

Fix #43