### PR TITLE
Optimize profile usage

### DIFF
--- a/src/main/java/de/codefor/le/crawler/CrawlScheduler.java
+++ b/src/main/java/de/codefor/le/crawler/CrawlScheduler.java
@@ -19,7 +19,7 @@ import de.codefor.le.repositories.PoliceTickerRepository;
 import lombok.RequiredArgsConstructor;
 
 @Component
-@Profile("crawl")
+@Profile({ "crawl", "test" })
 @RequiredArgsConstructor
 public class CrawlScheduler {
 

--- a/src/main/java/de/codefor/le/crawler/LvzPoliceTickerDetailViewCrawler.java
+++ b/src/main/java/de/codefor/le/crawler/LvzPoliceTickerDetailViewCrawler.java
@@ -15,7 +15,6 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.stereotype.Component;
@@ -43,7 +42,6 @@ import de.codefor.le.utilities.Utils;
  * @author spinner0815
  */
 @Component
-@Profile("crawl")
 public class LvzPoliceTickerDetailViewCrawler {
 
     private static final Logger logger = LoggerFactory.getLogger(LvzPoliceTickerDetailViewCrawler.class);

--- a/src/main/java/de/codefor/le/ner/NER.java
+++ b/src/main/java/de/codefor/le/ner/NER.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 
@@ -29,7 +28,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Component
-@Profile("crawl")
 @RequiredArgsConstructor
 public final class NER {
 

--- a/src/test/java/de/codefor/le/crawler/CrawlSchedulerTest.java
+++ b/src/test/java/de/codefor/le/crawler/CrawlSchedulerTest.java
@@ -15,7 +15,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import de.codefor.le.model.PoliceTicker;
 
-@ActiveProfiles({ "crawl", "test" })
+@ActiveProfiles("test")
 @SpringBootTest
 public class CrawlSchedulerTest {
 

--- a/src/test/java/de/codefor/le/crawler/ReplacementTest.java
+++ b/src/test/java/de/codefor/le/crawler/ReplacementTest.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 import de.codefor.le.model.PoliceTicker;
 import de.codefor.le.repositories.PoliceTickerRepository;
 
-@ActiveProfiles({ "test" })
+@ActiveProfiles("test")
 @SpringBootTest
 public class ReplacementTest {
 

--- a/src/test/java/de/codefor/le/ner/NERTest.java
+++ b/src/test/java/de/codefor/le/ner/NERTest.java
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles({ "crawl", "test" })
+@ActiveProfiles("test")
 @SpringBootTest
 public class NERTest {
 


### PR DESCRIPTION
Avoid spring context reloads by using identical profiles over all tests
and remove unnecessary profile usage for inexpensive beans.