### PR TITLE
feat(): use htmlunit instead of chrome driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
                  "org.seleniumhq.selenium:selenium-api:$seleniumVersion",
                  "org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion",
                  "org.seleniumhq.selenium:selenium-remote-driver:$seleniumVersion",
+                 "org.htmlunit:htmlunit:4.11.1"
 
   implementation("edu.stanford.nlp:stanford-corenlp:3.9.2") {
     // because https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-173761


### PR DESCRIPTION
Just a test if htmlunit could be an option.

It seems to work, but javascript is disabled because when it is enabled, script errors occur and the page cannot be parsed.
So if Javascript is required, this will not work.