### PR TITLE
feat(build): add java ci with github actions in combination with elasticsearch

### DIFF
--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -1,0 +1,59 @@
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [github-ci-for-java]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./
+
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.8.23
+        ports:
+          - 9200:9200
+        env:
+          cluster.name: policeticker
+          bootstrap.memory_lock: true
+          ES_JAVA_OPTS: -Xms1g -Xmx1g
+          node.name: policeticker-1
+          network.host: 0.0.0.0
+          discovery.type: single-node
+          discovery.zen.minimum_master_nodes: 1
+          xpack.security.enabled: false
+          xpack.monitoring.enabled: false
+          xpack.ml.enabled: false
+          xpack.graph.enabled: false
+          xpack.watcher.enabled: false
+        options: >-
+          --health-cmd "curl -f http://localhost:9200/_cluster/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Wait for Elasticsearch to be ready
+        run: |
+          echo "Waiting for Elasticsearch..."
+          until curl -s http://localhost:9200 | grep -q "cluster_name"; do
+            sleep 2
+          done
+          echo "Elasticsearch is up!"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Execute Gradle build
+        run: ./gradlew build

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 ![GitHub license](https://img.shields.io/github/license/CodeforLeipzig/lvz-viz.svg)
 [![Code Climate](https://codeclimate.com/github/CodeforLeipzig/lvz-viz/badges/gpa.svg)](https://codeclimate.com/github/CodeforLeipzig/lvz-viz)
 
+[![Java CI with Gradle](https://github.com/CodeforLeipzig/lvz-viz/actions/workflows/java_ci.yml/badge.svg)](https://github.com/CodeforLeipzig/lvz-viz/actions/workflows/java_ci.yml)
+
 ## Intro
 
 Visualization of [LVZ police ticker](https://www.lvz.de/Leipzig/Polizeiticker/Polizeiticker-Leipzig).


### PR DESCRIPTION
@sepe81 Hey maybe this is something for you.
I was able to create a github action with gradle and elasticsearch to test the app.

I'm not sure if all the env variables that are used in docker are needed here, but it works fine for now.