### PR TITLE
fix(ci): update trigger branch for Java CI workflow to master

### DIFF
--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -2,7 +2,7 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [main]
+    branches: [master]
 
 jobs:
   build:


### PR DESCRIPTION
Changed to master b/c the main branch doesn't exist for now. But if wanted we can move the master branch to main.