### PR TITLE
fix(): update copyright extraction logic and test cases

### DIFF
--- a/src/test/java/de/codefor/le/crawler/LvzPoliceTickerDetailViewCrawlerTest.java
+++ b/src/test/java/de/codefor/le/crawler/LvzPoliceTickerDetailViewCrawlerTest.java
@@ -56,7 +56,7 @@ class LvzPoliceTickerDetailViewCrawlerTest {
         assertThat(results).filteredOn(ticker -> ticker.getArticle().startsWith(ARTICLE)).hasSize(1).first()
                 .satisfies(ticker -> {
                     assertThat(ticker.getDatePublished()).isEqualTo(PUBLISHING_DATE);
-                    assertThat(ticker.getCopyright()).isEqualTo("Quelle: dpa");
+                    assertThat(ticker.getCopyright()).isEqualTo("LVZ");
                 });
 
         assertThat(results).filteredOn(ticker -> ticker.getArticle().contains("FFP2-Masken")).hasSize(1);
@@ -103,8 +103,8 @@ class LvzPoliceTickerDetailViewCrawlerTest {
 
     @ParameterizedTest
     @CsvSource({
-            "/unfall-im-leipziger-norden-motorrad-von-transporter-erfasst-fahrer-schwer-verletzt-DMCSVDGWNJ3EMPYYQZHGAW42W4.html, 25.05.2022 08:23:25, Quelle: Einsatzfahrten Leipzig",
-            "/leipzig-passant-findet-brandbombe-bei-der-weissen-elster-IUMQNWJHYTVQ25B22EBFOGDHFE.html, 12.06.2022 11:13:07, Quelle: dpa"
+            "/unfall-im-leipziger-norden-motorrad-von-transporter-erfasst-fahrer-schwer-verletzt-DMCSVDGWNJ3EMPYYQZHGAW42W4.html, 25.05.2022 08:23:25, LVZ",
+            "/leipzig-passant-findet-brandbombe-bei-der-weissen-elster-IUMQNWJHYTVQ25B22EBFOGDHFE.html, 12.06.2022 11:13:07, LVZ"
     })
     void extractPublishedDate(final String path,
             @JavaTimeConversionPattern("dd.MM.yyyy HH:mm:ss") final LocalDateTime published, final String copyright)


### PR DESCRIPTION
I saw that the tests were failing and took a look.

I can't remember how it was before, when the copyright was in the header.

I would now check whether it is in ArticleMeta, which is quite possible. If not, check at the very bottom of the article, otherwise leave it blank.
First check top:
<img width="710" height="434" alt="image" src="https://github.com/user-attachments/assets/0dda1763-3239-4e22-98f5-98b51795b724" />

Second check bottom:
<img width="1037" height="333" alt="image" src="https://github.com/user-attachments/assets/6f2a1d8b-1a24-4476-96dc-4bd72ee56a0b" />
